### PR TITLE
Add idea tracker CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ideas.json
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# text
+# Idea Tracker
+
+This repository provides a minimal command-line tool for jotting down ideas and reviewing them later.
+
+## Usage
+
+1. **Add an idea**
+
+   ```bash
+   python3 idea.py add "my cool idea"
+   ```
+
+2. **List saved ideas**
+
+   ```bash
+   python3 idea.py list
+   ```
+
+Ideas are stored locally in `ideas.json`. This file is ignored by Git.
+

--- a/idea.py
+++ b/idea.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Simple command-line idea tracker."""
+import sys
+import os
+import json
+from datetime import datetime
+
+DATA_FILE = "ideas.json"
+
+
+def load_data():
+    if os.path.exists(DATA_FILE):
+        with open(DATA_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return []
+
+
+def save_data(data):
+    with open(DATA_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def add_idea(text):
+    data = load_data()
+    data.append({"idea": text, "timestamp": datetime.now().isoformat(timespec="seconds")})
+    save_data(data)
+    print("Idea added.")
+
+
+def list_ideas():
+    data = load_data()
+    if not data:
+        print("No ideas recorded.")
+        return
+    for i, item in enumerate(data, 1):
+        print(f"{i}. {item['idea']} ({item['timestamp']})")
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+    if not argv or argv[0] in {"-h", "--help"}:
+        print("Usage: idea.py add <idea> | list")
+        return
+    if argv[0] == "add":
+        if len(argv) < 2:
+            print("Please provide an idea text.")
+        else:
+            add_idea(" ".join(argv[1:]))
+    elif argv[0] == "list":
+        list_ideas()
+    else:
+        print(f"Unknown command: {argv[0]}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small Python script (`idea.py`) to store and list ideas
- document how to use the idea tracker in `README.md`
- ignore generated files with `.gitignore`

## Testing
- `python3 -m py_compile idea.py`
- `python3 idea.py --help`


------
https://chatgpt.com/codex/tasks/task_e_684155e77f2c83279336b42dcac8683b