### PR TITLE
Update UI to Japanese and fix server responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Idea Tracker
 
-This repository provides a minimal command-line tool for jotting down ideas and
-reviewing them later.
+This repository provides a simple command-line tool for jotting down ideas and
+reviewing them later. A small web interface is also available.
 
 ## Usage
 
-1. **Add an idea**
+### 1. Add an idea
 
    ```bash
    python3 idea.py add "my cool idea" --date 2023-01-01 --done
@@ -13,7 +13,7 @@ reviewing them later.
    The `--date` option sets the idea's date (defaults to today). Use `--done` to
    mark that the idea has already been considered or implemented.
 
-2. **List saved ideas**
+### 2. List saved ideas
 
    ```bash
    python3 idea.py list
@@ -21,19 +21,20 @@ reviewing them later.
    Each idea is printed with its date and whether it has been done (`✓` for done,
    `x` for not yet).
 
-3. **Mark an idea as done**
+### 3. Mark an idea as done
 
    ```bash
    python3 idea.py done 1
    ```
    The number is the idea's position from the `list` command.
 
-4. **Use the GUI**
+### 4. Use the GUI
 
    ```bash
    python3 idea.py gui
    ```
-   This starts a local web server and opens your browser to
-   `http://localhost:8000` where you can add and view ideas in HTML.
+   Launches a local web server and opens your browser to
+   `http://localhost:8000`. The interface is in Japanese and the form is
+   centered on the page.
 
 Ideas are stored locally in `ideas.json`. This file is ignored by Git.

--- a/idea.py
+++ b/idea.py
@@ -101,16 +101,28 @@ class IdeaHandler(http.server.BaseHTTPRequestHandler):
             done = "done" in params
             if text:
                 add_idea(text, date=date, done=done)
-            self.send_response(204)
+                resp = "ok"
+            else:
+                resp = "no text"
+            data_bytes = resp.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(data_bytes)))
             self.end_headers()
+            self.wfile.write(data_bytes)
         elif self.path == "/done":
             length = int(self.headers.get("Content-Length", 0))
             data = self.rfile.read(length).decode()
             params = urllib.parse.parse_qs(data)
             idx = int(params.get("idx", ["-1"])[0])
             mark_done(idx)
-            self.send_response(204)
+            resp = "ok"
+            data_bytes = resp.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(data_bytes)))
             self.end_headers()
+            self.wfile.write(data_bytes)
         else:
             self.send_error(404)
 

--- a/index.html
+++ b/index.html
@@ -1,26 +1,28 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Idea Tracker</title>
+  <title>アイデア管理</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Idea Tracker</h1>
-  <form id="add-form" action="/add" method="post">
-    <label for="idea-text">Idea:</label>
-    <input type="text" name="idea" id="idea-text" size="40" placeholder="Write your next big thing" required>
-    <label for="date">Date:</label>
-    <input type="date" name="date" id="date">
-    <label for="done">Done:</label>
-    <input type="checkbox" name="done" id="done">
-    <input type="submit" value="Add Idea">
-  </form>
-  <div id="message" aria-live="polite"></div>
+  <main>
+    <h1>アイデア管理</h1>
+    <form id="add-form" action="/add" method="post">
+      <label for="idea-text">アイデア:</label>
+      <input type="text" name="idea" id="idea-text" size="40" placeholder="あなたの次のひらめきを入力" required>
+      <label for="date">日付:</label>
+      <input type="date" name="date" id="date">
+      <label for="done">完了:</label>
+      <input type="checkbox" name="done" id="done">
+      <input type="submit" value="追加">
+    </form>
+    <div id="message" aria-live="polite"></div>
 
-  <h2>Ideas</h2>
-  <ul id="idea-list"></ul>
+    <h2>アイデア一覧</h2>
+    <ul id="idea-list"></ul>
+  </main>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -6,7 +6,7 @@ async function fetchIdeas(){
     const ideas = await res.json();
     if(ideas.length === 0){
       const li = document.createElement('li');
-      li.textContent = 'No ideas recorded.';
+      li.textContent = 'アイデアはまだ登録されていません。';
       ul.appendChild(li);
       return;
     }
@@ -17,11 +17,11 @@ async function fetchIdeas(){
       const form = document.createElement('form');
       form.className = 'inline';
       form.innerHTML = `<input type="hidden" name="idx" value="${idx}">
-  <input type="submit" value="Mark done"${item.done ? ' disabled':''}>`;
+  <input type="submit" value="完了"${item.done ? ' disabled':''}>`;
       form.addEventListener('submit', async (e)=>{
         e.preventDefault();
         const data = new URLSearchParams(new FormData(form));
-        await fetch('/done', {method:'POST', body:data});
+        await fetch('/done', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:data});
         fetchIdeas();
       });
       li.appendChild(form);
@@ -29,7 +29,7 @@ async function fetchIdeas(){
     });
   }catch(err){
     const li = document.createElement('li');
-    li.textContent = 'Failed to load ideas.';
+    li.textContent = 'アイデアの読み込みに失敗しました。';
     ul.appendChild(li);
   }
 }
@@ -46,12 +46,12 @@ document.getElementById('add-form').addEventListener('submit', async (e)=>{
   const form = e.target;
   const data = new URLSearchParams(new FormData(form));
   try{
-    const res = await fetch('/add', {method:'POST', body:data});
+    const res = await fetch('/add', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:data});
     if(!res.ok) throw new Error();
-    showMessage('Idea added.');
+    showMessage('アイデアを追加しました。');
     form.reset();
   }catch(err){
-    showMessage('Failed to add idea', true);
+    showMessage('アイデアの追加に失敗しました。', true);
   }
   document.getElementById('date').valueAsNumber = Date.now() - new Date().getTimezoneOffset()*60000;
   fetchIdeas();

--- a/style.css
+++ b/style.css
@@ -1,4 +1,5 @@
-body{font-family:Arial, sans-serif;margin:40px;max-width:600px;}
+body{font-family:Arial, sans-serif;display:flex;justify-content:center;margin:40px;}
+main{max-width:600px;width:100%;}
 li{margin-bottom:0.5em;}
 li.done{color:gray;text-decoration:line-through;}
 form.inline{display:inline;margin-left:1em;}


### PR DESCRIPTION
## Summary
- localize web UI to Japanese
- center the form on the page
- return explicit responses from POST endpoints
- update README with current instructions

## Testing
- `python3 -m py_compile idea.py`


------
https://chatgpt.com/codex/tasks/task_e_6841677127ac832795c220eb5eeb517c